### PR TITLE
refactor: adding response_parameters to integration response

### DIFF
--- a/terraform/api/main.tf
+++ b/terraform/api/main.tf
@@ -63,6 +63,7 @@ resource "aws_api_gateway_integration_response" "agencies_lambda_integration_res
   resource_id = aws_api_gateway_method.agencies_resource_method.resource_id
   http_method = aws_api_gateway_method.agencies_resource_method.http_method
   status_code = aws_api_gateway_method_response.agencies_resource_method_response.status_code
+  response_parameters = {}
 
   response_templates = {
     "application/json" = <<EOF


### PR DESCRIPTION
The Terraform plan is alerting about a change in AWS: https://github.com/maxfrise/house-rentals-cloud-resources/pull/39#issuecomment-1609695587 

```
Terraform detected the following changes made outside of Terraform since the
last "terraform apply" which may have affected this plan:

  # module.maxfrise_api_gateway.aws_api_gateway_integration_response.agencies_lambda_integration_response has changed
  ~ resource "aws_api_gateway_integration_response" "agencies_lambda_integration_response" {
        id                  = "agir-8hbmj9nmrj-udh18b-POST-200"
      + response_parameters = {}
        # (5 unchanged attributes hidden)
    }

```

I believe is because we are not setting any value in terraform but AWS defaults to something to I'm adding it here so we don't get that alert.