### PR TITLE
refactor: response from lambda to match api expectation

### DIFF
--- a/functions/agencies/__TESTS__/handler.test.ts
+++ b/functions/agencies/__TESTS__/handler.test.ts
@@ -49,10 +49,10 @@ describe('agencies handler', () => {
 
       mockDB('agencies-test-table');
 
-      const response = await handler(mockedEvent, mockedContext, () => undefined) as Response<AgenciesResponse>;
+      const response = await handler(mockedEvent, mockedContext, () => undefined) as Response;
 
       expect(response.statusCode).toBe(StatusCodes.ok);
-      expect(response.body.agencyId).toBe(`${date.getTime()}-${mockedEvent.body.ownerId}`);
+      expect(JSON.parse(response.body).agencyId).toBe(`${date.getTime()}-${mockedEvent.body.ownerId}`);
     });
 
     it('Should execute creation correctly when optional values are not present', async () => {
@@ -62,10 +62,10 @@ describe('agencies handler', () => {
       mockDB('agencies-test-table');
 
       //@ts-ignore
-      const response = await handler(event, mockedContext, () => undefined) as Response<AgenciesResponse>;
+      const response = await handler(event, mockedContext, () => undefined) as Response;
 
       expect(response.statusCode).toBe(StatusCodes.ok);
-      expect(response.body.agencyId).toBe(`${date.getTime()}-${mockedEvent.body.ownerId}`);
+      expect(JSON.parse(response.body).agencyId).toBe(`${date.getTime()}-${mockedEvent.body.ownerId}`);
     });
 
     it('Should execute creation correctly when is prod', async () => {
@@ -74,10 +74,10 @@ describe('agencies handler', () => {
 
       mockDB('agencies-prod-table');
 
-      const response = await handler({ ...mockedEvent, environment: 'prod' }, mockedContext, () => undefined) as Response<AgenciesResponse>;
+      const response = await handler({ ...mockedEvent, environment: 'prod' }, mockedContext, () => undefined) as Response;
 
       expect(response.statusCode).toBe(StatusCodes.ok);
-      expect(response.body.agencyId).toBe(`${date.getTime()}-${mockedEvent.body.ownerId}`);
+      expect(JSON.parse(response.body).agencyId).toBe(`${date.getTime()}-${mockedEvent.body.ownerId}`);
     });
   });
 
@@ -85,25 +85,28 @@ describe('agencies handler', () => {
     it('Should return status 400 if ownerId is not provided', async () => {
       const event = { ...mockedEvent, body: { ...mockedEvent.body, ownerId: null } };
       //@ts-ignore
-      const response = await handler(event, mockedContext, () => undefined) as Response<AgenciesResponse>;
+      const response = await handler(event, mockedContext, () => undefined) as Response;
 
       expect(response.statusCode).toBe(StatusCodes.badRequest);
+      expect(response.body).toBe('');
     });
 
     it('Should return status 400 if action is not provided', async () => {
       const event = { ...mockedEvent, body: { ...mockedEvent.body, action: undefined } };
       //@ts-ignore
-      const response = await handler(event, mockedContext, () => undefined) as Response<AgenciesResponse>;
+      const response = await handler(event, mockedContext, () => undefined) as Response;
 
       expect(response.statusCode).toBe(StatusCodes.badRequest);
+      expect(response.body).toBe('');
     });
 
     it('Should return status 400 if action is not recognized', async () => {
       const event = { ...mockedEvent, body: { ...mockedEvent.body, action: 'WHATEVER' } };
       //@ts-ignore
-      const response = await handler(event, mockedContext, () => undefined) as Response<AgenciesResponse>;
+      const response = await handler(event, mockedContext, () => undefined) as Response;
 
       expect(response.statusCode).toBe(StatusCodes.badRequest);
+      expect(response.body).toBe('');
     });
   });
 
@@ -120,17 +123,19 @@ describe('agencies handler', () => {
 
     it('Should return status 500 if creation fails', async () => {
       mockDB('agencies-test-table', true);
-      const response = await handler(mockedEvent, mockedContext, () => undefined) as Response<AgenciesResponse>;
+      const response = await handler(mockedEvent, mockedContext, () => undefined) as Response;
 
       expect(response.statusCode).toBe(StatusCodes.error);
+      expect(response.body).toBe('');
       expect(console.error).toHaveBeenCalledTimes(2);
     });
 
     it('Should return status 500 if something wrong goes in dynamo process', async () => {
       mockDB('agencies-prod-table'); // Mocking a different table to mock a put in a non existance table
-      const response = await handler(mockedEvent, mockedContext, () => undefined) as Response<AgenciesResponse>;
+      const response = await handler(mockedEvent, mockedContext, () => undefined) as Response;
 
       expect(response.statusCode).toBe(StatusCodes.error);
+      expect(response.body).toBe('');
       expect(console.error).toHaveBeenCalledTimes(1);
       expect(console.error).toHaveBeenCalledWith('Error on dynamo DB');
     });

--- a/functions/agencies/src/index.ts
+++ b/functions/agencies/src/index.ts
@@ -1,16 +1,14 @@
-import { Handler } from 'aws-lambda';
+import { Handler, } from 'aws-lambda';
 
 import { AgenciesRequest, AgenciesResponse } from './types';
-import { Event, Response, StatusCodes } from '../../common';
+import { Event, Response, StatusCodes, defaultResponse } from '../../common';
 import { addAgency } from './actions';
 
-export const handler: Handler<Event<AgenciesRequest>, Response<AgenciesResponse>> = async (event) => {
+export const handler: Handler<Event<AgenciesRequest>, Response> = async (event) => {
   if (!event.body.action || !event.body.ownerId) {
     return {
+      ...defaultResponse,
       statusCode: StatusCodes.badRequest,
-      body: {
-        agencyId: null
-      }
     }
   }
 
@@ -19,25 +17,22 @@ export const handler: Handler<Event<AgenciesRequest>, Response<AgenciesResponse>
 
     if (agencyId) {
       return {
+        ...defaultResponse,
         statusCode: StatusCodes.ok,
-        body: {
+        body: JSON.stringify({
           agencyId
-        }
+        })
       }
     }
 
     return {
+      ...defaultResponse,
       statusCode: StatusCodes.error,
-      body: {
-        agencyId
-      }
     }
   }
 
   return {
+    ...defaultResponse,
     statusCode: StatusCodes.badRequest,
-    body: {
-      agencyId: null
-    }
   }
 };

--- a/functions/common/defaults/default-response.ts
+++ b/functions/common/defaults/default-response.ts
@@ -1,0 +1,10 @@
+import { StatusCodes } from "../types";
+
+export const defaultResponse = {
+  isBase64Encoded: false,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  statusCode: StatusCodes.error,
+  body: ''
+};

--- a/functions/common/defaults/index.ts
+++ b/functions/common/defaults/index.ts
@@ -1,0 +1,1 @@
+export * from './default-response';

--- a/functions/common/index.ts
+++ b/functions/common/index.ts
@@ -1,1 +1,2 @@
+export * from './defaults';
 export * from './types';

--- a/functions/common/types/response.ts
+++ b/functions/common/types/response.ts
@@ -4,7 +4,9 @@ export enum StatusCodes {
   "badRequest" = 400
 };
 
-export type Response<ResponseBody> = {
+export type Response = {
+  isBase64Encoded: boolean,
+  headers: {},
   statusCode: StatusCodes,
-  body: ResponseBody,
+  body: string,
 };


### PR DESCRIPTION
## Description

Modifying lambda response to match API expectation as when using AWS_PROXY the response has to meet the expectation so is sent correctly to the client.