### PR TITLE
fix: lambda bundling

### DIFF
--- a/functions/agencies/package.json
+++ b/functions/agencies/package.json
@@ -9,7 +9,7 @@
     "test": "tsc && eslint && vitest run --coverage",
     "test:watch": "vitest",
     "prebuild": "rm -rf dist",
-    "build": "esbuild src/index.ts --minify --sourcemap --platform=node --target=es2020 --outfile=dist/index.js"
+    "build": "esbuild src/index.ts --bundle --sourcemap --external:@aws-sdk/* --platform=node --target=es2020 --outfile=dist/index.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Description

Fixing the build script as local files were not being included in the lambda. I'm using the `--external` flag for @aws dependencies that are already provided within aws lambda container.

Also I removed the `--minify` as for debugging purposes is way easier to see non-minified code and given that this is aws I don't think there is a gain on minifying it.

## Screenshots

### Before
<img width="1840" alt="Screenshot 2023-06-28 at 10 41 38 PM" src="https://github.com/maxfrise/house-rentals-cloud-resources/assets/16787893/d17b5094-4159-4ea2-b894-cf74555f03c5">


### After
<img width="1840" alt="Screenshot 2023-06-28 at 10 40 35 PM" src="https://github.com/maxfrise/house-rentals-cloud-resources/assets/16787893/a053d8be-988b-4aff-b116-f9dab7e18f68">

