### PR TITLE
feat: adding dynamo permissions to iam role for lambdas

### DIFF
--- a/terraform/certs/lambdas/main.tf
+++ b/terraform/certs/lambdas/main.tf
@@ -12,6 +12,35 @@ resource "aws_iam_role" "iam_maxfrise_lambdas" {
         },
         "Effect": "Allow",
         "Sid": ""
+        },
+        {
+            "Sid": "ListAndDescribe",
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:List*",
+                "dynamodb:DescribeReservedCapacity*",
+                "dynamodb:DescribeLimits",
+                "dynamodb:DescribeTimeToLive"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "SpecificTable",
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:BatchGet*",
+                "dynamodb:DescribeStream",
+                "dynamodb:DescribeTable",
+                "dynamodb:Get*",
+                "dynamodb:Query",
+                "dynamodb:Scan",
+                "dynamodb:BatchWrite*",
+                "dynamodb:CreateTable",
+                "dynamodb:Delete*",
+                "dynamodb:Update*",
+                "dynamodb:PutItem"
+            ],
+            "Resource": "arn:aws:dynamodb:*:*:table/*"
         }
     ]
     }


### PR DESCRIPTION
Adding permissions to the iam role for lambdas so they can access to DB.