### PR TITLE
fix: dynamo putCommand in agencies lambda

### DIFF
--- a/functions/agencies/src/actions/add.ts
+++ b/functions/agencies/src/actions/add.ts
@@ -10,7 +10,7 @@ const ddb = DynamoDBDocumentClient.from(client);
 export const addAgency = async (request: AgenciesRequest, environment: Stage): Promise<ApiResponse<AgenciesResponse>> => {
   const tableName = environment === "prod" ? "agencies-prod-table" : "agencies-test-table";
   const date = new Date();
-  const agencyId = `${date.getTime()}-${request.ownerId}`;
+  const agencyId = `${date.getTime()}-${request.ownerId}`.toString();
 
   const newItemCommand = new PutCommand({
     Item: {

--- a/functions/agencies/src/actions/add.ts
+++ b/functions/agencies/src/actions/add.ts
@@ -10,25 +10,15 @@ const ddb = DynamoDBDocumentClient.from(client);
 export const addAgency = async (request: AgenciesRequest, environment: Stage): Promise<ApiResponse<AgenciesResponse>> => {
   const tableName = environment === "prod" ? "agencies-prod-table" : "agencies-test-table";
   const date = new Date();
-  const agencyId = `${date.getTime()}-${request.ownerId}`.toString();
+  const agencyId = `${date.getTime()}-${request.ownerId}`;
 
   const newItemCommand = new PutCommand({
     Item: {
-      agencyId: {
-        S: agencyId
-      },
-      owner: {
-        S: request.ownerId
-      },
-      address: {
-        S: request.address || ""
-      },
-      name: {
-        S: request.name || ""
-      },
-      phone: {
-        S: request.phone || ""
-      }
+      agencyId: agencyId,
+      owner: request.ownerId,
+      address: request.address || "",
+      name: request.name || "",
+      phone: request.phone
     },
     TableName: tableName
   });

--- a/functions/agencies/src/actions/add.ts
+++ b/functions/agencies/src/actions/add.ts
@@ -18,7 +18,7 @@ export const addAgency = async (request: AgenciesRequest, environment: Stage): P
       owner: request.ownerId,
       address: request.address || "",
       name: request.name || "",
-      phone: request.phone
+      phone: request.phone || ""
     },
     TableName: tableName
   });


### PR DESCRIPTION
The PutItem command is failing due to this error:

```
Type mismatch for key agencyId expected: S actual: M
```

Looking at some online posts seems like the new way of storing data in dynamo is using the direct value isntead of an object `{ S: value}`.