### PR TITLE
feat: adding agency status

### DIFF
--- a/functions/agencies/__TESTS__/actions/update-agency-status.test.ts
+++ b/functions/agencies/__TESTS__/actions/update-agency-status.test.ts
@@ -1,0 +1,119 @@
+import { mockClient } from 'aws-sdk-client-mock';
+import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { vi } from 'vitest';
+
+import { updateAgencyStatus } from '../../src/actions'
+import { MaxfriseErrorCodes, Response, Stage, StatusCodes } from '../../../common';
+import { AgenciesRequest, AgencyStatus } from '../../src/types';
+
+const mockedBodyRequest: AgenciesRequest = {
+  action: 'STATUS',
+  agencyId: 'agencyId',
+  ownerId: 'owner#email',
+  status: AgencyStatus.visible
+};
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+const mockDB = (tableName: string, rejects = false, item = null) => {
+  if (rejects) {
+    return ddbMock.on(UpdateCommand, { TableName: tableName }).rejects('Some dynamo error');
+  }
+
+  return ddbMock.on(UpdateCommand, item || { TableName: tableName }).resolves({
+    $metadata: {
+      httpStatusCode: 200
+    }
+  });
+}
+
+describe('updateAgencyStatus()', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    ddbMock.reset();
+  });
+
+  describe('Status Update - Success', () => {
+    it('Should execute status update correctly', async () => {
+      mockDB('agencies-test-table');
+
+      const response = await updateAgencyStatus(mockedBodyRequest, Stage.TEST) as Response;
+
+      expect(response.statusCode).toBe(StatusCodes.ok);
+    });
+
+    it('Should execute status update correctly when optional values are not present', async () => {
+      const request = { ...mockedBodyRequest, address: undefined, name: undefined, phone: undefined };
+
+      mockDB('agencies-test-table');
+
+      const response = await updateAgencyStatus(request, Stage.TEST) as Response;
+
+      expect(response.statusCode).toBe(StatusCodes.ok);
+    });
+
+    it('Should execute status update correctly when is prod', async () => {
+      mockDB('agencies-prod-table');
+
+      const response = await updateAgencyStatus(mockedBodyRequest, Stage.PROD) as Response;
+
+      expect(response.statusCode).toBe(StatusCodes.ok);
+    });
+  });
+
+  describe('Error: Bad request', () => {
+    it('Should return status 400 if agencyId is not provided', async () => {
+      const bodyRequest = { ...mockedBodyRequest, agencyId: undefined };
+
+      const response = await updateAgencyStatus(bodyRequest, Stage.PROD) as Response;
+
+      expect(response.statusCode).toBe(StatusCodes.badRequest);
+      expect(JSON.parse(response.body).response.errorMessage).toBe(MaxfriseErrorCodes.missingInfo.message);
+    });
+
+    it('Should return status 400 if ownerId is not provided', async () => {
+      const bodyRequest = { ...mockedBodyRequest, ownerId: undefined };
+
+      //@ts-ignore
+      const response = await updateAgencyStatus(bodyRequest, Stage.TEST) as Response;
+
+      expect(response.statusCode).toBe(StatusCodes.badRequest);
+      expect(JSON.parse(response.body).response.errorMessage).toBe(MaxfriseErrorCodes.missingInfo.message);
+    });
+
+    it('Should return status 400 if status is not provided', async () => {
+      const bodyRequest = { ...mockedBodyRequest, status: undefined };
+
+      const response = await updateAgencyStatus(bodyRequest, Stage.TEST) as Response;
+
+      expect(response.statusCode).toBe(StatusCodes.badRequest);
+      expect(JSON.parse(response.body).response.errorMessage).toBe(MaxfriseErrorCodes.missingInfo.message);
+    });
+  });
+
+  describe('Error: Server error', () => {
+    const errorLog = console.error;
+
+    beforeEach(() => {
+      console.error = vi.fn();
+    });
+
+    afterEach(() => {
+      console.error = errorLog;
+    });
+
+    it('Should return status 500 if update fails', async () => {
+      mockDB('agencies-test-table', true);
+
+      const response = await updateAgencyStatus(mockedBodyRequest, Stage.TEST) as Response;
+
+      expect(response.statusCode).toBe(StatusCodes.error);
+      expect(JSON.parse(response.body).response.errorMessage).toBe(MaxfriseErrorCodes.errorFromDynamo.message);
+      expect(console.error).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/functions/agencies/__TESTS__/handler.test.ts
+++ b/functions/agencies/__TESTS__/handler.test.ts
@@ -4,7 +4,7 @@ import { vi } from 'vitest';
 
 import { handler } from '../src';
 import { MaxfriseErrorCodes, Response, Stage, StatusCodes } from '../../common';
-import { AgenciesRequest } from '../src/types';
+import { AgenciesRequest, AgencyStatus } from '../src/types';
 import { getMockedEvent, mockedContext } from '../../__mocks__/';
 
 const mockedBodyRequest: AgenciesRequest = {
@@ -56,6 +56,17 @@ describe('agencies handler', () => {
 
     it('Should execute update correctly', async () => {
       const request = { ...mockedBodyRequest, action: 'UPDATE', agencyId: 'agencyId' };
+      mockDB('agencies-test-table');
+
+      const event = getMockedEvent(JSON.stringify(request));
+
+      const response = await handler(event, mockedContext, () => undefined) as Response;
+
+      expect(response.statusCode).toBe(StatusCodes.ok);
+    });
+
+    it('Should execute update STATUS correctly', async () => {
+      const request = { ...mockedBodyRequest, action: 'STATUS', agencyId: 'agencyId', status: AgencyStatus.visible };
       mockDB('agencies-test-table');
 
       const event = getMockedEvent(JSON.stringify(request));

--- a/functions/agencies/src/actions/add.ts
+++ b/functions/agencies/src/actions/add.ts
@@ -2,7 +2,7 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
 
 import { ApiResponse, MaxfriseErrorCodes, Stage } from '../../../common';
-import { AgenciesRequest, AgenciesResponse } from "../types";
+import { AgenciesRequest, AgenciesResponse, AgencyStatus } from "../types";
 
 const client = new DynamoDBClient({ region: "us-west-2" });
 const ddb = DynamoDBDocumentClient.from(client);
@@ -18,7 +18,8 @@ export const addAgency = async (request: AgenciesRequest, environment: Stage): P
       owner: request.ownerId,
       address: request.address || "",
       name: request.name || "",
-      phone: request.phone || ""
+      phone: request.phone || "",
+      status: request.status || AgencyStatus.visible
     },
     TableName: tableName
   });

--- a/functions/agencies/src/actions/index.ts
+++ b/functions/agencies/src/actions/index.ts
@@ -1,2 +1,3 @@
 export * from './add';
 export * from './update';
+export * from './update-agency-status';

--- a/functions/agencies/src/actions/update-agency-status.ts
+++ b/functions/agencies/src/actions/update-agency-status.ts
@@ -1,0 +1,62 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+
+import { ApiResponse, MaxfriseErrorCodes, Stage } from '../../../common';
+import { AgenciesRequest, AgenciesResponse, AgencyStatus } from "../types";
+
+const client = new DynamoDBClient({ region: "us-west-2" });
+const ddb = DynamoDBDocumentClient.from(client);
+
+export const updateAgencyStatus = async (request: AgenciesRequest, environment: Stage): Promise<ApiResponse<AgenciesResponse>> => {
+  const tableName = environment === "prod" ? "agencies-prod-table" : "agencies-test-table";
+
+  if (!request.agencyId || !request.ownerId || !request.status) {
+    return new ApiResponse<AgenciesResponse>(
+      MaxfriseErrorCodes.missingInfo.code,
+      {
+        response: {
+          errorMessage: MaxfriseErrorCodes.missingInfo.message
+        }
+      }
+    );
+  }
+
+  const updateItemCommand = new UpdateCommand({
+    ExpressionAttributeNames: {
+      "#s": "status",
+    },
+    ExpressionAttributeValues: {
+      ":status": request.status,
+    },
+    Key: {
+      agencyId: request.agencyId,
+      owner: request.ownerId // TODO: Instead of using the owner id from request, get from logged user
+    },
+    ReturnValues: "NONE",
+    TableName: tableName,
+    UpdateExpression: "SET #s = :status",
+  });
+
+  let result;
+  try {
+    result = await ddb.send(updateItemCommand);
+  } catch (e) {
+    console.error('Error on update command execution');
+    console.error(e);
+
+    return new ApiResponse<AgenciesResponse>(
+      MaxfriseErrorCodes.errorFromDynamo.code,
+      {
+        response: {
+          errorMessage: MaxfriseErrorCodes.errorFromDynamo.message
+        }
+      }
+    );
+  }
+
+  return new ApiResponse<AgenciesResponse>(200, {
+    response: {
+      agencyId: request.agencyId
+    }
+  }, {});
+};

--- a/functions/agencies/src/index.ts
+++ b/functions/agencies/src/index.ts
@@ -2,7 +2,7 @@ import { Handler, APIGatewayEvent } from 'aws-lambda';
 
 import { AgenciesRequest, AgenciesResponse } from './types';
 import { ApiResponse, getEnv, MaxfriseErrorCodes } from '../../common';
-import { addAgency, updateAgency } from './actions';
+import { addAgency, updateAgency, updateAgencyStatus } from './actions';
 
 export const handler: Handler<APIGatewayEvent, ApiResponse<AgenciesResponse>> = async (event) => {
   if (!event.body) {
@@ -15,10 +15,11 @@ export const handler: Handler<APIGatewayEvent, ApiResponse<AgenciesResponse>> = 
       }
     );
   }
+
   const environment = getEnv(event.requestContext.stage);
   const request = JSON.parse(event.body) as AgenciesRequest;
 
-  if (!request.action || !request.ownerId) {
+  if (!request.action || !request.ownerId) { // TODO: Add is signedIn() check
     return new ApiResponse<AgenciesResponse>(
       MaxfriseErrorCodes.missingInfo.code,
       {
@@ -33,6 +34,8 @@ export const handler: Handler<APIGatewayEvent, ApiResponse<AgenciesResponse>> = 
     return await addAgency(request, environment);
   } else if (request.action === 'UPDATE') {
     return await updateAgency(request, environment);
+  } else if (request.action === 'STATUS') {
+    return await updateAgencyStatus(request, environment);
   }
 
   return new ApiResponse<AgenciesResponse>(

--- a/functions/agencies/src/types/agencies-request.ts
+++ b/functions/agencies/src/types/agencies-request.ts
@@ -1,8 +1,15 @@
+export enum AgencyStatus {
+  archived = 'archived',
+  hidden = 'hidden',
+  visible = 'visible'
+};
+
 export type AgenciesRequest = {
-  action: 'CREATE' | 'UPDATE' | 'DELETE',
+  action: 'CREATE' | 'UPDATE' | 'STATUS',
   ownerId: string,
   agencyId?: string,
   address?: string
   name?: string,
-  phone?: string
+  phone?: string,
+  status?: AgencyStatus
 };


### PR DESCRIPTION
Adding the agency status, which will be used for this:

- Hidden, default when creating an agency, unless user chooses to create it visible. Also this could be used if for whatever reason the agency needs to be removed from the listings during a temp period of time.
- Visible, once the agency is ready to go live.
- Archived, when the agency is "deleted" but maintain recovery capability.